### PR TITLE
Allow client to get information about category group

### DIFF
--- a/assets/javascripts/discourse/components/collective-alert.js.es6
+++ b/assets/javascripts/discourse/components/collective-alert.js.es6
@@ -49,8 +49,8 @@ export default Ember.Component.extend({
     const collectiveGroup = category.collective_group;
 
     return currentUser.filteredGroups
-      .map(item => item.name)
-      .includes(collectiveGroup);
+      .map((item) => item.name)
+      .includes(collectiveGroup.name);
   },
 
   isCategoryCollective(category) {
@@ -159,7 +159,7 @@ export default Ember.Component.extend({
           // improve this is we find a better way to do it
           window.location.href = window.location.href;
         })
-        .catch(error => {
+        .catch((error) => {
           throw error;
         });
     },

--- a/assets/javascripts/discourse/components/collective-alert.js.es6
+++ b/assets/javascripts/discourse/components/collective-alert.js.es6
@@ -46,7 +46,7 @@ export default Ember.Component.extend({
       return false;
     }
 
-    const collectiveGroup = category.collective_group;
+    const collectiveGroup = category.tdc_collective_group;
 
     return currentUser.filteredGroups
       .map((item) => item.name)
@@ -54,7 +54,7 @@ export default Ember.Component.extend({
   },
 
   isCategoryCollective(category) {
-    return category && category.is_collective;
+    return category && category.tdc_is_collective;
   },
 
   // bind events for sticky scrolling

--- a/plugin.rb
+++ b/plugin.rb
@@ -84,6 +84,6 @@ after_initialize do
   end
 
   add_to_serializer(:basic_category, :collective_group) do
-    object.groups.where.not(id: Group::AUTO_GROUPS.values).first&.name
+    object.groups.where.not(id: Group::AUTO_GROUPS.values).first
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -79,11 +79,11 @@ after_initialize do
   Category.register_custom_field_type("tdc_is_collective", :boolean)
   Site.preloaded_category_custom_fields << "tdc_is_collective" if Site.respond_to? :preloaded_category_custom_fields
 
-  add_to_serializer(:basic_category, :is_collective) do
+  add_to_serializer(:basic_category, :tdc_is_collective) do
     !!object.custom_fields["tdc_is_collective"]
   end
 
-  add_to_serializer(:basic_category, :collective_group) do
+  add_to_serializer(:basic_category, :tdc_collective_group) do
     object.groups.where.not(id: Group::AUTO_GROUPS.values).first
   end
 end


### PR DESCRIPTION
**What:**
Update serialiser to expose category group object instead only name

**Why:**
We need to render the amount of people joined into a collective https://github.com/debtcollective/discourse-debtcollective-theme/pull/48

**Extras:**
Rename properties to have `tdc_` preffix