### PR TITLE
fix(collective-alert): only show collective alert when user is on a c…

### DIFF
--- a/assets/javascripts/discourse/components/collective-alert.js.es6
+++ b/assets/javascripts/discourse/components/collective-alert.js.es6
@@ -112,6 +112,10 @@ export default Ember.Component.extend({
       .css('width', `${mainOutletWidth}px`)
   },
 
+  isCollectivePage() {
+    return window.location.pathname.includes("/c");
+  },
+
   // unbind events and clean up
   willDestroyElement() {
     this._super(...arguments)
@@ -135,7 +139,8 @@ export default Ember.Component.extend({
     if (
       !currentUser ||
       !this.isCategoryCollective(category) ||
-      this.isCollectiveMember()
+      this.isCollectiveMember() ||
+      !this.isCollectivePage()
     ) {
       return this.set('hidden', true)
     }


### PR DESCRIPTION
**What:**
Only display the collective alert when user is on a collective page and not a member of it

**Why:**
If a member went to a collective page and then go back to the main page, the collective alert was still showing. Once it was rendered it never disappeared.

If applied, this PR will fix this [Asana task](https://app.asana.com/0/1159164196409156/1177383629910291/f)

**How:**
By adding extra validation on `didReceiveAttrs` component life cycle that checks whether the user is looking at a collective page or not

Media:
https://www.loom.com/share/a059efcd13714eee8394ae11425ae17e
